### PR TITLE
Add project property to avoid reading personal gradle.properties file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,4 +94,6 @@ task wrapper(type: Wrapper) {
     gradleVersion = '4.4.1'
 }
 
-apply from: 'maven.gradle'
+if (project.hasProperty("PUBLISH")) {
+    apply from: 'maven.gradle'
+}


### PR DESCRIPTION
I added a test on a new project property PUBLISH.
If present, build.gradle script will also run task from maven.gradle script file, ie. publication to Nexus repository